### PR TITLE
Colored Coins API v3 is rejecting fee < 1000 satoshis

### DIFF
--- a/src/js/coloredcoins/services/ccFeeService.js
+++ b/src/js/coloredcoins/services/ccFeeService.js
@@ -31,6 +31,10 @@ angular.module('copayAddon.coloredCoins')
           var size = _getEstimatedSize(nbInputs, nbOutputs);
           $log.debug("Estimated size: " + size);
           var fee = feePerKb * size / 1000;
+
+          // Colored Coins API v3 rejects fee lower than 1000 satoshis (http://coloredcoins.org/documentation/#IssueAsset)
+          fee = fee < 1000 ? 1000 : fee; 
+
           fee = parseInt(fee.toFixed(0));
           $log.debug("Estimated fee: " + fee);
           return cb(null, fee);


### PR DESCRIPTION
@troggy , I don't know if it is the best way to handle it, but I noticed that Colored Coins API is rejecting asset issuance with < 1000 satoshis